### PR TITLE
Normalize indicator LED configuration handling

### DIFF
--- a/ui/anduril/aux-leds.h
+++ b/ui/anduril/aux-leds.h
@@ -24,19 +24,52 @@
     ((((lock_mode) & INDICATOR_LED_OFF_MASK) << INDICATOR_LED_LOCKOUT_SHIFT) \
      | ((off_mode) & INDICATOR_LED_OFF_MASK))
 
-static inline uint8_t indicator_led_get_off_mode(uint8_t value) {
+static inline uint8_t indicator_led_get_off_field(uint8_t value) {
     return value & INDICATOR_LED_OFF_MASK;
 }
 
-static inline uint8_t indicator_led_get_lockout_mode(uint8_t value) {
+static inline uint8_t indicator_led_get_lock_field(uint8_t value) {
     return (value & INDICATOR_LED_LOCKOUT_MASK) >> INDICATOR_LED_LOCKOUT_SHIFT;
 }
 
+static inline uint8_t indicator_led_normalize(uint8_t value) {
+    uint8_t off = indicator_led_get_off_field(value);
+    uint8_t lock = indicator_led_get_lock_field(value);
+
+    if ((off >= INDICATOR_LED_NUM_MODES) || (lock >= INDICATOR_LED_NUM_MODES)) {
+        uint8_t legacy_off = value & 0x03;
+        uint8_t legacy_lock = (value >> 2) & 0x03;
+        off = legacy_off;
+        lock = legacy_lock;
+    }
+
+    if (off >= INDICATOR_LED_NUM_MODES) {
+        off %= INDICATOR_LED_NUM_MODES;
+    }
+    if (lock >= INDICATOR_LED_NUM_MODES) {
+        lock %= INDICATOR_LED_NUM_MODES;
+    }
+
+    return INDICATOR_LED_COMPOSE(off, lock);
+}
+
+static inline uint8_t indicator_led_get_off_mode(uint8_t value) {
+    return indicator_led_get_off_field(indicator_led_normalize(value));
+}
+
+static inline uint8_t indicator_led_get_lockout_mode(uint8_t value) {
+    return indicator_led_get_lock_field(indicator_led_normalize(value));
+}
+
 static inline uint8_t indicator_led_set_off_mode(uint8_t value, uint8_t mode) {
+    value = indicator_led_normalize(value);
+    mode %= INDICATOR_LED_NUM_MODES;
     return (value & (~INDICATOR_LED_OFF_MASK)) | (mode & INDICATOR_LED_OFF_MASK);
 }
 
 static inline uint8_t indicator_led_set_lockout_mode(uint8_t value, uint8_t mode) {
+    value = indicator_led_normalize(value);
+    mode %= INDICATOR_LED_NUM_MODES;
     return (value & (~INDICATOR_LED_LOCKOUT_MASK))
         | ((mode & INDICATOR_LED_OFF_MASK) << INDICATOR_LED_LOCKOUT_SHIFT);
 }

--- a/ui/anduril/load-save-config.c
+++ b/ui/anduril/load-save-config.c
@@ -6,11 +6,18 @@
 
 #include "anduril/load-save-config-fsm.h"
 #include "anduril/load-save-config.h"
+#ifdef USE_INDICATOR_LED
+#include "anduril/aux-leds.h"
+#endif
 
 void load_config() {
     eeprom = (uint8_t *)&cfg;
 
     if (! load_eeprom()) return;
+
+#ifdef USE_INDICATOR_LED
+    cfg.indicator_led_mode = indicator_led_normalize(cfg.indicator_led_mode);
+#endif
 
     #ifdef START_AT_MEMORIZED_LEVEL
     if (load_eeprom_wl()) {

--- a/ui/fireflies-ui/fireflies-ui.c
+++ b/ui/fireflies-ui/fireflies-ui.c
@@ -2169,7 +2169,7 @@ void load_config() {
         therm_cal_offset = eeprom[therm_cal_offset_e];
         #endif
         #ifdef USE_INDICATOR_LED
-        indicator_led_mode = eeprom[indicator_led_mode_e];
+        indicator_led_mode = indicator_led_normalize(eeprom[indicator_led_mode_e]);
         #endif
     }
     #ifdef START_AT_MEMORIZED_LEVEL

--- a/ui/rampingios/rampingiosv3.c
+++ b/ui/rampingios/rampingiosv3.c
@@ -1154,7 +1154,7 @@ void load_config() {
         therm_cal_offset = eeprom[EEPROM_BYTES_BASE+1];
         #endif
         #ifdef USE_INDICATOR_LED
-        indicator_led_mode = eeprom[EEPROM_BYTES_BASE+EEPROM_THERMAL_BYTES];
+        indicator_led_mode = indicator_led_normalize(eeprom[EEPROM_BYTES_BASE+EEPROM_THERMAL_BYTES]);
         #endif
     }
 }


### PR DESCRIPTION
## Summary
- add normalization helpers so indicator LED mode values translate legacy EEPROM layouts and clamp to supported ranges
- normalize the persisted indicator LED mode when loading configs in Anduril, RampingIOS, and Fireflies UIs so existing lights keep their intended aux LED behavior

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de55b7a500832eb79bb649b405cba2